### PR TITLE
regress/fcgi: dump and check all the parameters

### DIFF
--- a/regress/lib.sh
+++ b/regress/lib.sh
@@ -9,6 +9,31 @@ current_test=
 server_name=
 gghost=
 
+fcgi_content() {
+	remote_host=::1
+	if [ "$HAVE_IPV6" != yes ]; then
+		remote_host=127.0.0.1
+	fi
+
+	cat <<EOF
+Here's the parameters I've got:
+* AUTH_TYPE=
+* GATEWAY_INTERFACE=CGI/1.1
+* GEMINI_URL_PATH=${fcgi_path_info##/}
+* PATH_INFO=$fcgi_path_info
+* PATH_TRANSLATED=$fcgi_path
+* QUERY_STRING=
+* REMOTE_ADDR=$remote_host
+* REMOTE_HOST=$remote_host
+* REQUEST_METHOD=GET
+* SCRIPT_NAME=
+* SERVER_NAME=<redacted>
+* SERVER_PORT=$port
+* SERVER_PROTOCOL=GEMINI
+* SERVER_SOFTWARE=$($gmid -V | awk '{print $2 "/" $3}')
+EOF
+}
+
 run_test() {
 	ggflags=
 	host="$REGRESS_HOST"
@@ -16,6 +41,8 @@ run_test() {
 	proxy_port=10966
 	proxy=
 	config_common="log syslog off"
+	fcgi_path_info=/
+	fcgi_path="$PWD/testdata/"
 	hdr=
 	body=
 	dont_check_server_alive=no

--- a/regress/tests.sh
+++ b/regress/tests.sh
@@ -306,12 +306,10 @@ test_fastcgi() {
 
 	setup_simple_test 'prefork 1' 'fastcgi socket "'$PWD'/fcgi.sock"'
 
-	msg=$(printf "# hello from fastcgi!\nsome more content in the page...")
-
 	i=0
 	while [ $i -lt 10 ]; do
 		fetch /
-		check_reply "20 text/gemini" "$msg"
+		check_reply "20 text/gemini" "$(fcgi_content)"
 		if [ $? -ne 0 ]; then
 			kill $fcgi_pid
 			return 1
@@ -327,15 +325,16 @@ test_fastcgi() {
 test_fastcgi_inside_location() {
 	./fcgi-test fcgi.sock &
 	fcgi_pid=$!
+	fcgi_path_info="/foo"
+	fcgi_path="$PWD/testdata/foo"
 
 	setup_simple_test 'prefork 1' 'fastcgi socket "'$PWD'/fcgi.sock"
 	location "/dir/*" {
 		fastcgi off
 	}'
 
-	msg=$(printf "# hello from fastcgi!\nsome more content in the page...")
 	fetch /foo
-	if ! check_reply "20 text/gemini" "$msg"; then
+	if ! check_reply "20 text/gemini" "$(fcgi_content)"; then
 		kill $fcgi_pid
 		return 1
 	fi
@@ -353,6 +352,8 @@ test_fastcgi_inside_location() {
 test_fastcgi_location_match() {
 	./fcgi-test fcgi.sock &
 	fcgi_pid=$!
+	fcgi_path_info="/foo"
+	fcgi_path="$PWD/testdata/foo"
 
 	setup_simple_test 'prefork 1' '
 	location "/dir/*" {
@@ -362,9 +363,8 @@ test_fastcgi_location_match() {
 		fastcgi socket "'$PWD'/fcgi.sock"
 	}'
 
-	msg=$(printf "# hello from fastcgi!\nsome more content in the page...")
 	fetch /foo
-	if ! check_reply "20 text/gemini" "$msg"; then
+	if ! check_reply "20 text/gemini" "$(fcgi_content)"; then
 		kill $fcgi_pid
 		return 1
 	fi
@@ -387,9 +387,8 @@ test_fastcgi_deprecated_syntax() {
 	# backward compatibility works.
 	setup_simple_test 'prefork 1' 'fastcgi "'$PWD'/fcgi.sock"'
 
-	msg=$(printf "# hello from fastcgi!\nsome more content in the page...")
 	fetch /
-	check_reply "20 text/gemini" "$msg"
+	check_reply "20 text/gemini" "$(fcgi_content)"
 	if [ $? -ne 0 ]; then
 		kill $fcgi_pid
 		return 1


### PR DESCRIPTION
This would have caught #36.

Actually, this fails since there's a weird `PATH_TRANSLATED` when using fastcgi in a location block.